### PR TITLE
fix spelling of note and element

### DIFF
--- a/data/tutorial2.egi
+++ b/data/tutorial2.egi
@@ -64,7 +64,7 @@
    ["We combine numbers using '[]'.\nThese things are called 'tuples'."
     {"[1 2]" "[1 2 3]"}
     {}]
-   ["Please not that a tuple that consists of only one elment is equal with that element itself."
+   ["Please note that a tuple that consists of only one element is equal with that element itself."
     {"[1]" "[[[1]]]"}
     {}]
    ["Try to create a sequce of tuples '{[1 1] [1 2] [1 3] [1 4] [1 5] [1 6] [1 7] [1 8] [1 9]}'."


### PR DESCRIPTION
The sentence

> Please not that a tuple that consists of only one elment is equal with that element itself

has 'note' and 'element' misspelled.
