### PR TITLE
Fix getEgisonExprOrNewLine

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -2,7 +2,7 @@ module Main where
 
 import Prelude hiding (catch)
 import Control.Exception ( AsyncException(..), catch )
-import Control.Monad.Error
+import Control.Monad.Except
 
 import Data.Version
 import Data.List


### PR DESCRIPTION
Fixes the arguments passed to `getEgisonExprOrNewLine` to make `egison-tutorial` compatible with `egison-3.7.14`.
(The cabal file has been unchanged.)

The other commit is a minor one that replaces a deprecated module with a newer version.
